### PR TITLE
Modify response header/body extraction method

### DIFF
--- a/lib/viadeoapi.inc.php
+++ b/lib/viadeoapi.inc.php
@@ -671,8 +671,11 @@ class ViadeoAPI {
             throw new ViadeoConnectionException(curl_error($ch));
         }
 
-        list($headers, $body) = explode("\r\n\r\n", $result);
+        $result_sections = explode("\r\n\r\n", $result);
+        $body = end($result_sections);
+        $header = prev($result_sections);
         $result = json_decode($body);
+
 
         $ex = null;
         if (isset($result->error)) {


### PR DESCRIPTION
Avoid bug happening when there is more than 1 header which actually cause $body to be the second header. 
We now assume that response body is ever the last part of the response (and not the second part).
